### PR TITLE
Moose

### DIFF
--- a/lib/Net/GitHub/V2/HasRepo.pm
+++ b/lib/Net/GitHub/V2/HasRepo.pm
@@ -2,10 +2,10 @@ package Net::GitHub::V2::HasRepo;
 
 use Any::Moose 'Role';
 
-our $VERSION = '0.13';
+our $VERSION = '0.14';
 our $AUTHORITY = 'cpan:FAYLAND';
 
-with 'Net::GitHub::V2::NoRepo' => { excludes => [ 'args_to_pass' ] };;
+with 'Net::GitHub::V2::NoRepo' => { -excludes => [ 'args_to_pass' ] };;
 
 # repo stuff
 has 'repo'  => ( isa => 'Str', is => 'ro', required => 1 );


### PR DESCRIPTION
This small change fixes that fat warning. Moose::Manual::Delta mentions that change for 0.89_01, now they've deprecated it with a full blown backtrace.

```
github> repo datamuc perl-net-github
The alias and excludes options for role application have been renamed -alias and -excludes (Net::GitHub::V2::HasRepo is consuming Net::GitHub::V2::NoRepo - do you need to upgrade Net::GitHub::V2::HasRepo?) at /home/danielt/perl5/perlbrew/perls/perl-5.12.1t/lib/site_perl/5.12.1/Net/GitHub/V2/HasRepo.pm line 8
        require Net/GitHub/V2/HasRepo.pm called at /home/danielt/perl5/perlbrew/perls/perl-5.12.1t/lib/site_perl/5.12.1/i686-linux-thread-multi/Class/MOP.pm line 114
        Class::MOP::__ANON__() called at /home/danielt/perl5/perlbrew/perls/perl-5.12.1t/lib/site_perl/5.12.1/Try/Tiny.pm line 71
        eval {...} called at /home/danielt/perl5/perlbrew/perls/perl-5.12.1t/lib/site_perl/5.12.1/Try/Tiny.pm line 67
        Try::Tiny::try('CODE(0x9d51358)', 'Try::Tiny::Catch=REF(0x9acd080)') called at /home/danielt/perl5/perlbrew/perls/perl-5.12.1t/lib/site_perl/5.12.1/i686-linux-thread-multi/Class/MOP.pm line 125
        Class::MOP::load_first_existing_class('Net::GitHub::V2::HasRepo') called at /home/danielt/perl5/perlbrew/perls/perl-5.12.1t/lib/site_perl/5.12.1/i686-linux-thread-multi/Class/MOP.pm line 137
        Class::MOP::load_class('Net::GitHub::V2::HasRepo', undef) called at /home/danielt/perl5/perlbrew/perls/perl-5.12.1t/lib/site_perl/5.12.1/i686-linux-thread-multi/Moose/Util.pm line 113
        Moose::Util::_apply_all_roles('Moose::Meta::Class=HASH(0x9d322c8)', undef, 'Net::GitHub::V2::HasRepo') called at /home/danielt/perl5/perlbrew/perls/perl-5.12.1t/lib/site_perl/5.12.1/i686-linux-thread-multi/Moose/Util.pm line 91
        Moose::Util::apply_all_roles('Moose::Meta::Class=HASH(0x9d322c8)', 'Net::GitHub::V2::HasRepo') called at /home/danielt/perl5/perlbrew/perls/perl-5.12.1t/lib/site_perl/5.12.1/i686-linux-thread-multi/Moose.pm line 58
        Moose::with('Moose::Meta::Class=HASH(0x9d322c8)', 'Net::GitHub::V2::HasRepo') called at /home/danielt/perl5/perlbrew/perls/perl-5.12.1t/lib/site_perl/5.12.1/i686-linux-thread-multi/Moose/Exporter.pm line 359
        Moose::with('Net::GitHub::V2::HasRepo') called at /home/danielt/perl5/perlbrew/perls/perl-5.12.1t/lib/site_perl/5.12.1/Net/GitHub/V2/Repositories.pm line 10
        require Net/GitHub/V2/Repositories.pm called at /home/danielt/perl5/perlbrew/perls/perl-5.12.1t/lib/site_perl/5.12.1/Net/GitHub/V2.pm line 8
        Net::GitHub::V2::BEGIN() called at /home/danielt/perl5/perlbrew/perls/perl-5.12.1t/lib/site_perl/5.12.1/Net/GitHub/V2/HasRepo.pm line 0
        eval {...} called at /home/danielt/perl5/perlbrew/perls/perl-5.12.1t/lib/site_perl/5.12.1/Net/GitHub/V2/HasRepo.pm line 0
        require Net/GitHub/V2.pm called at /home/danielt/perl5/perlbrew/perls/perl-5.12.1t/lib/site_perl/5.12.1/Net/GitHub.pm line 17
        Net::GitHub::new('Net::GitHub', 'owner', 'datamuc', 'repo', 'perl-net-github') called at /home/danielt/perl5/perlbrew/perls/perl-5.12.1t/lib/site_perl/5.12.1/App/GitHub.pm line 371
        App::GitHub::set_repo('App::GitHub=HASH(0x91d3570)', 'datamuc perl-net-github') called at /home/danielt/perl5/perlbrew/perls/perl-5.12.1t/lib/site_perl/5.12.1/App/GitHub.pm line 267
        App::GitHub::run('App::GitHub=HASH(0x91d3570)') called at /home/danielt/perl5/perlbrew/perls/current/bin/github.pl line 11
```
