### PR TITLE
use official GitHub API request instead of screen-scraping

### DIFF
--- a/lib/Net/GitHub/V2/Issues.pm
+++ b/lib/Net/GitHub/V2/Issues.pm
@@ -225,18 +225,17 @@ comment on issues
 
 =item comments
 
-note: this is not the official api of github, in fact,
-      it's done by scrapping.
-
     my $comments = $issue->comments( $number );
 
 return an arrayref containing a list of comments, each comment is a hashref like
 
     {
-        id      => 12345,
-        author  => 'foo',
-        date    => '2009/06/08 18:28:42 -0700',
-        content => 'blalba',
+        id           => 12345,
+        gravatar_id  => 12345,
+        user         => 'foo',
+        created_at   => '2009/06/08 18:28:42 -0700',
+        modified_at  => '2009/06/08 18:28:42 -0700',
+        body         => 'blalba',
     }
 
 if no comments, return []


### PR DESCRIPTION
hi, as of some time GitHub has had an official method for getting the comments on a ticket (see http://develop.github.com/p/issues.html).

These commits update Net::GitHub to use it.

They are not backwards-compatible with the old screen-scraping call. If you want to have backwards compatibility, you could do something like adding the old members to the array refs, or have some sort of flag...

I believe the equivalence is something like:
id => id
author => user
content => body
date => created_at
