### PR TITLE
Use utf8 => 1 for JSON::Any by default.

### DIFF
--- a/lib/Net/GitHub/V2/NoRepo.pm
+++ b/lib/Net/GitHub/V2/NoRepo.pm
@@ -59,7 +59,7 @@ has 'json' => (
     isa => 'JSON::Any',
     lazy => 1,
     default => sub {
-        return JSON::Any->new;
+        return JSON::Any->new( utf8 => 1 );
     }
 );
 


### PR DESCRIPTION
This was contributed by my colleague @jamesronan, who observed that fetching the
diff for a commit which touched binary files failed, as the JSON response from
GitHub could not be parsed by `JSON::Any` without `utf8 => 1` being set.
