### PR TITLE
Fixed typo in Net::GitHub::V2::NoRepo.pm that crippled App::GitHub

### DIFF
--- a/lib/Net/GitHub/V2/NoRepo.pm
+++ b/lib/Net/GitHub/V2/NoRepo.pm
@@ -83,8 +83,8 @@ sub get_json_to_obj {
     # By the way GitHub mistakes days for minutes in their documentation --
     # the rate limit is per minute, not per day.
     if ( $self->api_throttle ) {
-        sleep 2 if (($res->header('x-ratelimit-remaining') || 0)
-            < ($res->header('x-ratelimit-limit') || 60) / 2);
+        sleep 2 if (($resp->header('x-ratelimit-remaining') || 0)
+            < ($resp->header('x-ratelimit-limit') || 60) / 2);
     }
 
     return { error => '404 Not Found' } if $resp->code == 404;


### PR DESCRIPTION
There is a bug in Net::GitHub::V2::NoRepo that causes calls to App::GitHub::set_repo() to fail consistently. This is a minor patch that fixes that issue.
