### PR TITLE
Fixed URI encoding issue

### DIFF
--- a/lib/Net/GitHub/V3/Search.pm
+++ b/lib/Net/GitHub/V3/Search.pm
@@ -19,7 +19,12 @@ sub repositories {
 
     my $uri = URI->new('/search/repositories');
     $uri->query_form($args);
-    return $self->query($uri->as_string);
+
+    my $url = $uri->as_string;
+    $url =~ s/%3A/:/g;
+    $url =~ s/%2B/+/g;
+
+    return $self->query($url);
 }
 
 sub code {


### PR DESCRIPTION
 I'm getting a validation error on search parameters:

```
$search->repositories('language:perl+created:>2014-08-28');
# validation error
```

Reason is that GitHub API does not like the URL to be URI encoded. You can replicate in your browser:

fails:
https://api.github.com/search/repositories?q=language%3Aperl%2Bcreated%3A%3E2014-08-28

works:
https://api.github.com/search/repositories?q=language:perl+created:%3E2014-08-29

I patched Search.pm to replace the troublesome symbols.
