### PR TITLE
Author tests for all

### DIFF
--- a/xt/v3/01-access-token.t
+++ b/xt/v3/01-access-token.t
@@ -19,5 +19,3 @@ ok( $data->{login} );
 ok( $data->{name} );
 
 done_testing;
-
-1;

--- a/xt/v3/02-user-pass.t
+++ b/xt/v3/02-user-pass.t
@@ -20,5 +20,3 @@ ok( $data->{login} );
 ok( $data->{name} );
 
 done_testing;
-
-1;

--- a/xt/v3/100-users.t
+++ b/xt/v3/100-users.t
@@ -56,5 +56,3 @@ if ($is_following) {
 =cut
 
 done_testing;
-
-1;

--- a/xt/v3/200-repos.t
+++ b/xt/v3/200-repos.t
@@ -50,5 +50,3 @@ is($st, 1);
 =cut
 
 done_testing;
-
-1;

--- a/xt/v3/300-pull.t
+++ b/xt/v3/300-pull.t
@@ -25,5 +25,3 @@ for my $request (@closed_pull_requests) {
 }
 
 done_testing;
-
-1;

--- a/xt/v3/500-org.t
+++ b/xt/v3/500-org.t
@@ -34,5 +34,3 @@ $is_member = $org->is_member('perlchina', 'nothingmuch');
 is($is_member, 0);
 
 done_testing;
-
-1;

--- a/xt/v3/600-git_data.t
+++ b/xt/v3/600-git_data.t
@@ -27,5 +27,3 @@ is $commit->{sha}, '5a1faac3ad54da26be60970ddbbdfbf6b08fdc57';
 is $commit->{message}, "init git data";
 
 done_testing();
-
-1;

--- a/xt/v3/700-gists.t
+++ b/xt/v3/700-gists.t
@@ -30,5 +30,3 @@ is $g->{description}, "the description for this gist";
 is $g->{files}{"file1.txt"}{content}, "String file contents";
 
 done_testing;
-
-1;

--- a/xt/v3/800-oauth.t
+++ b/xt/v3/800-oauth.t
@@ -30,5 +30,3 @@ $oauth->delete_authorization($o->{id});
 ok !$oauth->authorization($o->{id});
 
 done_testing;
-
-1;

--- a/xt/v3/900-search.t
+++ b/xt/v3/900-search.t
@@ -26,5 +26,3 @@ for my $item (@$items) {
 }
 
 done_testing;
-
-1;


### PR DESCRIPTION
Hi,

I fixed up the author tests so they will run with any given Github username and password.  This makes it easier for others to work on Net::GitHub.  I also replaced the dumps with actual tests.  I didn't look too close to see what the tests modify about the account, but I have a separate test account.  This isn't 100%, but it's way more usable than it was before.
- I couldn't get the oauth credential creation test to work.
- I couldn't get the blob test to work, it appears to be a problem on Github's side.

Most of the tests are read-only and probably don't need credentials.

For the future, I would suggest making a separate Github account just for the tests to use and hard code the API token.  This is what Gitpan does.
