### PR TITLE
Include additional error information from the API when croaking

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,9 @@
 Revision history for Net-GitHub
 
+0.71    2014-12-??
+        - When a query fails, include any additional error messages returned by the API,
+          in the croak message.
+
 0.70    2014-10-08
         add per_page in GET no matter it supports or not
 

--- a/lib/Net/GitHub/V3/Query.pm
+++ b/lib/Net/GitHub/V3/Query.pm
@@ -177,7 +177,19 @@ sub query {
     }
 
     if ( $self->RaiseError ) {
-        croak $data->{message} if not $res->is_success and ref $data eq 'HASH' and exists $data->{message}; # for 'Client Errors'
+        # check for 'Client Errors'
+        if (not $res->is_success and ref $data eq 'HASH' and exists $data->{message}) {
+            my $message = $data->{message};
+
+            # Include any additional error information that was returned by the API
+            if (exists $data->{errors}) {
+                $message .= ': '.join(' - ',
+                                     map { $_->{message} }
+                                     grep { exists $_->{message} }
+                                     @{ $data->{errors} });
+            }
+            croak $message;
+        }
     }
 
     $self->_clear_pagination;


### PR DESCRIPTION
Hi!

I was trying a code search, but just getting an error message "Validation Failed",
which wasn't very helpful. I tried the search in the browser, and got this response:

```
{
  "message": "Validation Failed",
  "errors": [
    {
      "message": "Must include at least one user, organization, or repository",
      "resource": "Search",
      "field": "q",
      "code": "invalid"
    }
  ],
  "documentation_url": "https://developer.github.com/v3/search/#search-code"
}
```

Ahh, that inner message explained my problem.

This change takes any additional 'message' strings found in the 'errors' array,
and appends them on the error message. So now my (broken) script croaks with:

```
Validation Failed: Must include at least one user, organization, or repository
```

Much better! :-)
