### PR TITLE
Make User-Agent header conform to RFCs

### DIFF
--- a/lib/Net/GitHub/V3/Query.pm
+++ b/lib/Net/GitHub/V3/Query.pm
@@ -86,7 +86,7 @@ has 'ua' => (
     lazy    => 1,
     default => sub {
         LWP::UserAgent->new(
-            agent       => "perl-net-github $VERSION",
+            agent       => "perl-net-github/$VERSION",
             cookie_jar  => {},
             keep_alive  => 4,
             timeout     => 60,


### PR DESCRIPTION
They like `foo/1.2`, not `foo 1.2`.  See [2616 section 3.8](http://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html#sec3.8) or later.