### PR TITLE
adding support for passing permission to add_team_repos

### DIFF
--- a/examples/add_team_repos.pl
+++ b/examples/add_team_repos.pl
@@ -1,0 +1,24 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+use FindBin qw/$Bin/;
+use lib "$Bin/../lib";
+use Net::GitHub::V3;
+use Data::Dumper;
+
+die unless ( ($ENV{GITHUB_USER} and $ENV{GITHUB_PASS}) or $ENV{GITHUB_ACCESS_TOKEN} );
+
+# either user+pass or token
+my $gh = Net::GitHub::V3->new( login => $ENV{GITHUB_USER}, pass => $ENV{GITHUB_PASS});
+# my $gh = Net::GitHub->new( access_token => $ENV{GITHUB_ACCESS_TOKEN});
+
+my $x = $gh->repos->create({
+    name => "Foo-Bar-Baz",
+    org => "Yoink", 
+});
+
+$gh->org->add_team_repos($team_id, "Yoink/Foo-Bar-Baz", { permission => 'admin' })
+  or die ("Could not add or update team on repository with permission admin");
+
+1;

--- a/lib/Net/GitHub/V3/Orgs.pm
+++ b/lib/Net/GitHub/V3/Orgs.pm
@@ -40,7 +40,7 @@ my %__methods = (
     delete_team_member => { url => "/teams/%s/members/%s", method => 'DELETE', check_status => 204 },
     team_repos => { url => "/teams/%s/repos" },
     is_team_repos  => { url => "/teams/%s/repos/%s", check_status => 204 },
-    add_team_repos => { url => "/teams/%s/repos/%s", method => 'PUT', check_status => 204 },
+    add_team_repos => { url => "/teams/%s/repos/%s", method => 'PUT', args => 1, check_status => 204 },
     delete_team_repos => { url => "/teams/%s/repos/%s", method => 'DELETE', check_status => 204 },
 );
 __build_methods(__PACKAGE__, %__methods);
@@ -167,6 +167,9 @@ L<http://developer.github.com/v3/orgs/teams/>
     my @repos = $org->team_repos($team_id);
     my $is_team_repos = $org->is_team_repos($team_id, 'Hello-World');
     my $st = $org->add_team_repos($team_id, 'Hello-World');
+    my $st = $org->add_team_repos($team_id, 'YoinkOrg/Hello-World', { permission => 'admin' });
+    my $st = $org->add_team_repos($team_id, 'YoinkOrg/Hello-World', { permission => 'push' });
+    my $st = $org->add_team_repos($team_id, 'YoinkOrg/Hello-World', { permission => 'pull' });
     my $st = $org->delete_team_repos($team_id, 'Hello-World');
 
 =back


### PR DESCRIPTION
Hi @fayland,

Ref: https://developer.github.com/v3/orgs/teams/#add-or-update-team-repository

adding support to Orgs.pm for passing permission arg to this API call.  Example included.

Regards,

Leigh