### PR TITLE
Adding some Pagination helpers & better server error handling

### DIFF
--- a/lib/Net/GitHub/V3/Query.pm
+++ b/lib/Net/GitHub/V3/Query.pm
@@ -246,6 +246,21 @@ sub next_page {
     return $self->query($self->next_url);
 }
 
+sub prev_page {
+    my $self = shift;
+    return $self->query($self->prev_url);
+}
+
+sub first_page {
+    my $self = shift;
+    return $self->query($self->first_url);
+}
+
+sub last_page {
+    my $self = shift;
+    return $self->query($self->last_url);
+}
+
 sub _clear_pagination {
     my $self = shift;
     foreach my $page (qw/first last prev next/) {
@@ -436,6 +451,20 @@ Refer L<Net::GitHub::V3>
 =item next_page
 
 Calls C<query> with C<next_url>. See L<Net::GitHub::V3>
+
+=item prev_page
+
+Calls C<query> with C<prev_url>. See L<Net::GitHub::V3>
+
+=item first_page
+
+Calls C<query> with C<first_url>. See L<Net::GitHub::V3>
+
+=item last_page
+
+Calls C<query> with C<last_url>. See L<Net::GitHub::V3>
+
+
 
 =back
 

--- a/lib/Net/GitHub/V3/Query.pm
+++ b/lib/Net/GitHub/V3/Query.pm
@@ -13,6 +13,8 @@ use URI::Escape;
 use Types::Standard qw(Int Str Bool InstanceOf Object);
 use Cache::LRU;
 
+use Scalar::Util qw(looks_like_number);
+
 use Moo::Role;
 
 # configurable args
@@ -241,6 +243,25 @@ sub query {
     return $data;
 }
 
+sub set_next_page {
+    my ($self, $page) = @_;
+
+    if( ! looks_like_number($page) ){
+	    croak "Trying to set_next_page to $page, and not a number\n";
+    }
+
+    if( $page > $self->total_page && $page > 0 ){
+	    return 0;
+    }
+
+    my $temp_url = $self->next_url;
+    $temp_url =~ s/([&?])page=[0-9]+([&?]*)/$1page=$page$2/;
+
+    $self->next_url( $temp_url );
+
+    return 1;
+}
+
 sub next_page {
     my $self = shift;
     return $self->query($self->next_url);
@@ -464,7 +485,10 @@ Calls C<query> with C<first_url>. See L<Net::GitHub::V3>
 
 Calls C<query> with C<last_url>. See L<Net::GitHub::V3>
 
+=item set_next_page
 
+Adjusts next_url to be a new url in the pagination space
+I.E. you are jumping to a new index in the pagination
 
 =back
 

--- a/lib/Net/GitHub/V3/Query.pm
+++ b/lib/Net/GitHub/V3/Query.pm
@@ -38,6 +38,7 @@ has 'last_url'  => ( is => 'rw', isa => Str, predicate => 'has_last_page',  clea
 has 'first_url' => ( is => 'rw', isa => Str, predicate => 'has_first_page', clearer => 'clear_first_url' );
 has 'prev_url'  => ( is => 'rw', isa => Str, predicate => 'has_prev_page',  clearer => 'clear_prev_url' );
 has 'per_page'  => ( is => 'rw', isa => Str, default => 100 );
+has 'total_pages'  => ( is => 'rw', isa => Str, default => 0 );
 
 # Error handle
 has 'RaiseError' => ( is => 'rw', isa => Bool, default => 1 );
@@ -268,6 +269,12 @@ sub _extract_link_url {
 
         my $url_attr = $rel . "_url";
         $self->$url_attr($link_url);
+
+        # Grab, and expose, some additional header information
+	if( $rel eq "last" ){
+	    $link_url =~ /[\&?]page=([0-9]*)[\&?]*/;
+	    $self->total_pages( $1 );
+	}
     }
 
     return 1;
@@ -409,6 +416,10 @@ The number of requests remaining in the current rate limit window.
 =item rate_limit_reset
 
 The time the current rate limit resets in UTC epoch seconds.
+
+=item last_page
+
+Denotes the index of the last page in the pagination
 
 =item RaiseError
 


### PR DESCRIPTION
This adds some pagination helpers, noting it does not in any way enable automatic pagination, but it allows a program to jump around in the pagination should it need to.

It also adds some slight HTTP error handling in the event that GitHub's servers throw an error on a query, which is most likely transient, and allow for a transparent recovery should it not be too cumbersome, otherwise it will return identically up the stack.