### PR TITLE
Add item-per-item iteration so that users don't need to manage "pages" of results

### DIFF
--- a/lib/Net/GitHub/V3.pm
+++ b/lib/Net/GitHub/V3.pm
@@ -243,7 +243,7 @@ See Github's documentation: L<http://developer.github.com/v3/#pagination>
   }
 
 
-=head3 Iterating over items: next_xxx and close_xxx
+=head3 Iterating over individual items: next_xxx and close_xxx
 
 The queries which can return paginated results can also be evaluated one by
 one, like this:
@@ -252,16 +252,35 @@ one, like this:
     # do something with $issue
   }
 
-The arguments to next_repos_issue are the same as for repos_issues.
-In that case, new API calls will be performed only when needed to fetch more
-items.  An undefined return value means there are no more items.  Do not
-ignore this return value because the next call to next_repos_issues will,
-once again, start from the first issue.
+The arguments to next_repos_issue are the same as for repos_issues,
+and is also applicable to all other interfaces which offer a next_xxx
+method.  All available next_xxx methods are listed in the
+documentation of the corresponding modules, see the list below.
 
-If you want to start over with the first item without having to fetch all
-items, call the corresponding close method:
+If you loop over the next_xxx interfaces, new API calls will be
+performed automatically, but only when needed to fetch more items.  An
+undefined return value means there are no more items.
+
+To start over with the first item, you need to close the iteration.
+Every next_xxx method has a corresponding close_xxx method which must
+be called with exactly the same parameters as the next_xxx method to
+take effect:
 
   $gh->issue->close_repos_issue(@args);
+
+If you use Net::GitHub::V3 in a command line program, there is no need
+to call the close_xxx methods at all.  As soon as the Net::GitHub::V3
+object $gh goes out of scope, everything is neatly cleaned up.
+
+However, if you have a long-lived Net::GitHub::V3 object, e.g. in a
+persistent service process which provides an own interface to its
+users and talks to GitHub under the hood, then it is advisable to
+close the iterations when you're done with them.
+
+For brevity and because they usually are not needed, the close_xxx
+methods are not listed with their modules.  It is guaranteed that
+I<every> next_xxx method has a corresponding close_xxx method.
+
 
 
 =head3 ua

--- a/lib/Net/GitHub/V3.pm
+++ b/lib/Net/GitHub/V3.pm
@@ -222,7 +222,7 @@ from the API. By switching B<RaiseError> on you can make the be turned into
 exceptions instead, so that you don't have to check for error response after
 every call.
 
-=head3 next_url, last_url, prev_url, first_url, per_page
+=head3 Iterating over pages: next_url, last_url, prev_url, first_url, per_page
 
 Any methods which return multiple results I<may> be paginated. After performing
 a query you should check to see if there are more results. These attributes will
@@ -241,6 +241,28 @@ See Github's documentation: L<http://developer.github.com/v3/#pagination>
       ## OR ##
       push @issues, $gh->issue->next_page;
   }
+
+
+=head3 Iterating over items: next_xxx and close_xxx
+
+The queries which can return paginated results can also be evaluated one by
+one, like this:
+
+  while (my $issue = $gh->issue->next_repos_issue( @args )) {
+    # do something with $issue
+  }
+
+The arguments to next_repos_issue are the same as for repos_issues.
+In that case, new API calls will be performed only when needed to fetch more
+items.  An undefined return value means there are no more items.  Do not
+ignore this return value because the next call to next_repos_issues will,
+once again, start from the first issue.
+
+If you want to start over with the first item without having to fetch all
+items, call the corresponding close method:
+
+  $gh->issue->close_repos_issue(@args);
+
 
 =head3 ua
 

--- a/lib/Net/GitHub/V3.pm
+++ b/lib/Net/GitHub/V3.pm
@@ -304,7 +304,7 @@ L<Net::GitHub::V3::Repos>
 =head3 issue
 
     my @issues = $gh->issue->issues();
-    my $issue  = $gh->issue->issue($issue_id);
+    my $issue  = $gh->issue->issue($issue_number);
 
 L<Net::GitHub::V3::Issues>
 

--- a/lib/Net/GitHub/V3/Events.pm
+++ b/lib/Net/GitHub/V3/Events.pm
@@ -12,19 +12,19 @@ with 'Net::GitHub::V3::Query';
 ## build methods on fly
 my %__methods = (
 
-    events => { url => '/events' },
-    repos_events => { url => "/repos/%s/%s/events" },
-    issues_events => { url => "/repos/%s/%s/issues/events" },
-    networks_events => { url => "/networks/%s/%s/events" },
-    orgs_events => { url => "/orgs/%s/events" },
+    events => { url => '/events', paginate => 1 },
+    repos_events => { url => "/repos/%s/%s/events", paginate => 1 },
+    issues_events => { url => "/repos/%s/%s/issues/events", paginate => 1 },
+    networks_events => { url => "/networks/%s/%s/events", paginate => 1 },
+    orgs_events => { url => "/orgs/%s/events", paginate => 1 },
 
-    user_received_events => { url => "/users/%s/received_events" },
-    user_public_received_events => { url => "/users/%s/received_events/public" },
+    user_received_events => { url => "/users/%s/received_events", paginate => 1 },
+    user_public_received_events => { url => "/users/%s/received_events/public", paginate => 1 },
 
-    user_events => { url => "/users/%s/events" },
-    user_public_events => { url => "/users/%s/events/public" },
+    user_events => { url => "/users/%s/events", paginate => 1 },
+    user_public_events => { url => "/users/%s/events/public", paginate => 1 },
 
-    user_orgs_events => { url => "/users/%s/events/orgs/%s" },
+    user_orgs_events => { url => "/users/%s/events/orgs/%s", paginate => 1 },
 
 );
 __build_methods(__PACKAGE__, %__methods);
@@ -51,13 +51,14 @@ Net::GitHub::V3::Events - GitHub Events API
 
 =head3 Events
 
-L<http://developer.github.com/v3/events/>
+L<http://developer.github.com/v3/activity/events/>
 
 =over 4
 
 =item events
 
     my @events = $event->events();
+    while (my $ne = $event->next_event) { ...; }
 
 =item repos_events
 
@@ -68,10 +69,14 @@ L<http://developer.github.com/v3/events/>
     my @events = $event->repos_events($user, $repo);
     my @events = $event->issues_events($user, $repo);
     my @events = $event->networks_events($user, $repo);
+    while (my $ur_event = next_repos_event($user,$repo) { ...; }
+    while (my $ur_event = next_issues_event($user,$repo) { ...; }
+    while (my $ur_event = next_networks_event($user,$repo) { ...; }
 
 =item orgs_events
 
     my @events = $event->orgs_events($org);
+    while (my $org_event = $event->next_orgs_event) { ...; }
 
 =item user_received_events
 
@@ -85,10 +90,15 @@ L<http://developer.github.com/v3/events/>
     my @events = $event->user_public_received_events($user);
     my @events = $event->user_events($user);
     my @events = $event->user_public_events($user);
+    while (my $u_event = $event->next_user_received_event) { ...; }
+    while (my $u_event = $event->next_user_public_received_event) { ...; }
+    while (my $u_event = $event->next_user_event) { ...; }
+    while (my $u_event = $event->next_user_public_event) { ...; }
 
 =item user_orgs_events
 
     my @events = $event->user_orgs_events($user, $org);
+    while (my $o_event = $event->next_org_event) { ...; }
 
 =back
 

--- a/lib/Net/GitHub/V3/Gists.pm
+++ b/lib/Net/GitHub/V3/Gists.pm
@@ -16,10 +16,24 @@ sub gists {
     return $self->query($u);
 }
 
+sub next_gist {
+    my ( $self, $user ) = @_;
+
+    my $u = $user ? "/users/" . uri_escape($user) . '/gists' : '/gists';
+    return $self->next($u);
+}
+
+sub close_gist {
+    my ( $self, $user ) = @_;
+
+    my $u = $user ? "/users/" . uri_escape($user) . '/gists' : '/gists';
+    return $self->close($u);
+}
+
 ## build methods on fly
 my %__methods = (
-    public_gists  => { url => "/gists/public" },
-    starred_gists => { url => "/gists/starred" },
+    public_gists  => { url => "/gists/public", paginate => 1 },
+    starred_gists => { url => "/gists/starred", paginate => 1 },
     gist => { url => "/gists/%s" },
     create => { url => "/gists", method => "POST", args => 1 },
     update => { url => "/gists/%s", method => "PATCH", args => 1 },
@@ -30,7 +44,7 @@ my %__methods = (
     delete => { url => "/gists/%s", method => "DELETE", check_status => 204 },
 
     # http://developer.github.com/v3/gists/comments/
-    comments => { url => "/gists/%s/comments" },
+    comments => { url => "/gists/%s/comments", paginate => 1 },
     comment  => { url => "/gists/%s/comments/%s" },
     create_comment => { url => "/gists/%s/comments", method => 'POST',  args => 1 },
     update_comment => { url => "/gists/%s/comments/%s", method => 'PATCH', args => 1 },
@@ -68,6 +82,7 @@ L<http://developer.github.com/v3/gists/>
 
     my @gists = $gist->gists;
     my @gists = $gist->gists('nothingmuch');
+    while (my $g = $gist->next_gist) { ...; }
 
 =item public_gists
 
@@ -75,6 +90,8 @@ L<http://developer.github.com/v3/gists/>
 
     my @gists = $gist->public_gists;
     my @gists = $gist->starred_gists;
+    while (my $g = $gist->next_public_gist) { ...; }
+    while (my $g = $gist->next_starred_gist) { ...; }
 
 =item gist
 
@@ -134,6 +151,7 @@ L<http://developer.github.com/v3/gists/comments/>
 =item delete_comment
 
     my @comments = $gist->comments();
+    while (my $c = $gist->next_comment) { ...; }
     my $comment  = $gist->comment($comment_id);
     my $comment  = $gist->create_comment($gist_id, {
         "body" => "a new comment"

--- a/lib/Net/GitHub/V3/Issues.pm
+++ b/lib/Net/GitHub/V3/Issues.pm
@@ -156,7 +156,7 @@ B<To ease the keyboard, we provied two ways to call any method which starts with
 
 =item issue
 
-    my $issue = $issue->issue($issue_id);
+    my $issue = $issue->issue($issue_number);
 
 =item create_issue
 
@@ -173,7 +173,7 @@ B<To ease the keyboard, we provied two ways to call any method which starts with
 
 =item update_issue
 
-    my $isu = $issue->update_issue( $issue_id, {
+    my $isu = $issue->update_issue( $issue_number, {
         state => 'closed'
     } );
 
@@ -195,9 +195,9 @@ L<http://developer.github.com/v3/issues/comments/>
 
 =item delete_comment
 
-    my @comments = $issue->comments($issue_id);
+    my @comments = $issue->comments($issue_number);
     my $comment  = $issue->comment($comment_id);
-    my $comment  = $issue->create_comment($issue_id, {
+    my $comment  = $issue->create_comment($issue_number, {
         "body" => "a new comment"
     });
     my $comment = $issue->update_comment($comment_id, {
@@ -217,7 +217,7 @@ L<http://developer.github.com/v3/issues/events/>
 
 =item repos_events
 
-    my @events = $issue->events($issue_id);
+    my @events = $issue->events($issue_number);
     my @events = $issue->repos_events;
     my $event  = $issue->event($event_id);
 
@@ -263,12 +263,12 @@ L<http://developer.github.com/v3/issues/labels/>
 
 =item milestone_labels
 
-    my @labels = $issue->issue_label($issue_id);
-    my @labels = $issue->create_issue_label($issue_id, ['New Label']);
-    my $st = $issue->delete_issue_label($issue_id, $label_name);
-    my @labels = $issue->replace_issue_label($issue_id, ['New Label']);
-    my $st = $issue->delete_issue_labels($issue_id);
-    my @lbales = $issue->milestone_labels($milestone_id);
+    my @labels = $issue->issue_label($issue_number);
+    my @labels = $issue->create_issue_label($issue_number, ['New Label']);
+    my $st = $issue->delete_issue_label($issue_number, $label_name);
+    my @labels = $issue->replace_issue_label($issue_number, ['New Label']);
+    my $st = $issue->delete_issue_labels($issue_number);
+    my @lables = $issue->milestone_labels($milestone_id);
 
 =back
 

--- a/lib/Net/GitHub/V3/Issues.pm
+++ b/lib/Net/GitHub/V3/Issues.pm
@@ -107,7 +107,7 @@ my %__methods = (
     milestone_labels => { url => "/repos/%s/%s/milestones/%s/labels", paginate => 1 },
 
     # http://developer.github.com/v3/issues/milestones/
-    milestone  => { url => "/repos/%s/%s/milestones/%s", paginate => 1 },
+    milestone  => { url => "/repos/%s/%s/milestones/%s" },
     create_milestone => { url => "/repos/%s/%s/milestones", method => 'POST',  args => 1 },
     update_milestone => { url => "/repos/%s/%s/milestones/%s", method => 'PATCH', args => 1 },
     delete_milestone => { url => "/repos/%s/%s/milestones/%s", method => 'DELETE', check_status => 204 },

--- a/lib/Net/GitHub/V3/Issues.pm
+++ b/lib/Net/GitHub/V3/Issues.pm
@@ -11,20 +11,54 @@ with 'Net::GitHub::V3::Query';
 
 sub issues {
     my $self = shift;
-    my $args = @_ % 2 ? shift : { @_ };
 
+    return $self->query(_issues_arg2url(@_));
+}
+
+sub next_issue {
+    my $self = shift;
+
+    return $self->next(_issues_arg2url(@_));
+}
+
+sub close_issue {
+    my $self = shift;
+
+    return $self->close(_issues_arg2url(@_));
+}
+
+
+sub _issues_arg2url {
+    my $args = @_ % 2 ? shift : { @_ };
     my @p;
     foreach my $p (qw/filter state labels sort direction since/) {
         push @p, "$p=" . $args->{$p} if exists $args->{$p};
     }
     my $u = '/issues';
     $u .= '?' . join('&', @p) if @p;
-    return $self->query($u);
+    return $u;
 }
 
 sub repos_issues {
     my $self = shift;
 
+    return $self->query($self->_repos_issues_arg2url(@_));
+}
+
+sub next_repos_issue {
+    my $self = shift;
+
+    return $self->next($self->_repos_issues_arg2url(@_));
+}
+
+sub close_repos_issue {
+    my $self = shift;
+
+    return $self->close($self->_repos_issues_arg2url(@_));
+}
+
+sub _repos_issues_arg2url {
+    my $self = shift;
     if (@_ < 2) {
         unshift @_, $self->repo;
         unshift @_, $self->u;
@@ -37,7 +71,7 @@ sub repos_issues {
     }
     my $u = "/repos/" . uri_escape($user) . "/" . uri_escape($repos) . '/issues';
     $u .= '?' . join('&', @p) if @p;
-    return $self->query($u);
+    return $u;
 }
 
 ## build methods on fly
@@ -48,32 +82,32 @@ my %__methods = (
     update_issue => { url => "/repos/%s/%s/issues/%s", method => 'PATCH', args => 1 },
 
     ## http://developer.github.com/v3/issues/comments/
-    comments => { url => "/repos/%s/%s/issues/%s/comments" },
+    comments => { url => "/repos/%s/%s/issues/%s/comments", paginate => 1 },
     comment  => { url => "/repos/%s/%s/issues/comments/%s" },
     create_comment => { url => "/repos/%s/%s/issues/%s/comments", method => 'POST',  args => 1 },
     update_comment => { url => "/repos/%s/%s/issues/comments/%s", method => 'PATCH', args => 1 },
     delete_comment => { url => "/repos/%s/%s/issues/comments/%s", method => 'DELETE', check_status => 204 },
 
     # http://developer.github.com/v3/issues/events/
-    events => { url => "/repos/%s/%s/issues/%s/events" },
-    repos_events => { url => "/repos/%s/%s/issues/events" },
+    events => { url => "/repos/%s/%s/issues/%s/events", paginate => 1 },
+    repos_events => { url => "/repos/%s/%s/issues/events" , paginate => 1 },
     event => { url => "/repos/%s/%s/issues/events/%s" },
 
     # http://developer.github.com/v3/issues/labels/
-    labels => { url => "/repos/%s/%s/labels" },
+    labels => { url => "/repos/%s/%s/labels", paginate => 1 },
     label  => { url => "/repos/%s/%s/labels/%s" },
     create_label => { url => "/repos/%s/%s/labels", method => 'POST', args => 1 },
     update_label => { url => "/repos/%s/%s/labels/%s", method => 'PATCH', args => 1 },
     delete_label => { url => "/repos/%s/%s/labels/%s", method => 'DELETE', check_status => 204 },
-    issue_labels => { url => "/repos/%s/%s/issues/%s/labels" },
+    issue_labels => { url => "/repos/%s/%s/issues/%s/labels", paginate => 1 },
     create_issue_label  => { url => "/repos/%s/%s/issues/%s/labels", method => 'POST', args => 1 },
     delete_issue_label  => { url => "/repos/%s/%s/issues/%s/labels/%s", method => 'DELETE', check_status => 204 },
     replace_issue_label => { url => "/repos/%s/%s/issues/%s/labels", method => 'PUT', args => 1 },
     delete_issue_labels => { url => "/repos/%s/%s/issues/%s/labels", method => 'DELETE', check_status => 204 },
-    milestone_labels => { url => "/repos/%s/%s/milestones/%s/labels" },
+    milestone_labels => { url => "/repos/%s/%s/milestones/%s/labels", paginate => 1 },
 
     # http://developer.github.com/v3/issues/milestones/
-    milestone  => { url => "/repos/%s/%s/milestones/%s" },
+    milestone  => { url => "/repos/%s/%s/milestones/%s", paginate => 1 },
     create_milestone => { url => "/repos/%s/%s/milestones", method => 'POST',  args => 1 },
     update_milestone => { url => "/repos/%s/%s/milestones/%s", method => 'PATCH', args => 1 },
     delete_milestone => { url => "/repos/%s/%s/milestones/%s", method => 'DELETE', check_status => 204 },
@@ -83,6 +117,24 @@ __build_methods(__PACKAGE__, %__methods);
 
 ## http://developer.github.com/v3/issues/milestones/
 sub milestones {
+    my $self = shift;
+
+    return $self->query($self->_milestones_arg2url(@_));
+}
+
+sub next_milestone {
+    my $self = shift;
+
+    return $self->next($self->_milestones_arg2url(@_));
+}
+
+sub close_milestone {
+    my $self = shift;
+
+    return $self->close($self->_milestones_arg2url(@_));
+}
+
+sub _milestones_arg2url {
     my $self = shift;
 
     if (@_ < 3) {
@@ -97,7 +149,7 @@ sub milestones {
     }
     my $u = "/repos/" . uri_escape($user) . "/" . uri_escape($repos) . '/milestones';
     $u .= '?' . join('&', @p) if @p;
-    return $self->query($u);
+    return $u;
 }
 
 no Moo;
@@ -130,6 +182,10 @@ L<http://developer.github.com/v3/issues/>
 
     my @issues = $issue->issues();
     my @issues = $issue->issues(filter => 'assigned', state => 'open');
+    while (my $next_issue = $issues->next_issue(...)) { ...; }
+
+Returns issues assigned to the authenticated user.
+
 
 =back
 
@@ -153,6 +209,7 @@ B<To ease the keyboard, we provied two ways to call any method which starts with
     my @issues = $issue->repos_issues($user, $repos);
     my @issues = $issue->repos_issues( { state => 'open' } );
     my @issues = $issue->repos_issues($user, $repos, { state => 'open' } );
+    while (my $r_issue = $issue->next_repos_issue(...)) { ...; }
 
 =item issue
 
@@ -196,6 +253,7 @@ L<http://developer.github.com/v3/issues/comments/>
 =item delete_comment
 
     my @comments = $issue->comments($issue_number);
+    while (my $comment = $issue->next_comment($issue_number)) { ...; }
     my $comment  = $issue->comment($comment_id);
     my $comment  = $issue->create_comment($issue_number, {
         "body" => "a new comment"
@@ -218,7 +276,9 @@ L<http://developer.github.com/v3/issues/events/>
 =item repos_events
 
     my @events = $issue->events($issue_number);
+    while (my $event = $issue->next_event($issue_number)) { ...; }
     my @events = $issue->repos_events;
+    while (my $r_event = $issue->next_repos_event) { ...; }
     my $event  = $issue->event($event_id);
 
 =back
@@ -240,6 +300,7 @@ L<http://developer.github.com/v3/issues/labels/>
 =item delete_label
 
     my @labels = $issue->labels;
+    while (my $label = $issue->next_label) { ...; }
     my $label  = $issue->label($label_name);
     my $label  = $issue->create_label( {
         "name" => "API",
@@ -263,12 +324,13 @@ L<http://developer.github.com/v3/issues/labels/>
 
 =item milestone_labels
 
-    my @labels = $issue->issue_label($issue_number);
+    my @labels = $issue->issue_labels($issue_number);
     my @labels = $issue->create_issue_label($issue_number, ['New Label']);
     my $st = $issue->delete_issue_label($issue_number, $label_name);
     my @labels = $issue->replace_issue_label($issue_number, ['New Label']);
     my $st = $issue->delete_issue_labels($issue_number);
     my @lables = $issue->milestone_labels($milestone_id);
+    while (my $label = $issue->next_milestone_label($milestone_id)) { ...; }
 
 =back
 
@@ -290,6 +352,7 @@ L<http://developer.github.com/v3/issues/milestones/>
 
     my @milestones = $issue->milestones;
     my @milestones = $issue->milestones( { state => 'open' } );
+    while (my $milestone = $issue->next_milestone( ... )) { ...; }
     my $milestone  = $issue->milestone($milestone_id);
     my $milestone  = $issue->create_milestone( {
         "title" => "String",

--- a/lib/Net/GitHub/V3/Query.pm
+++ b/lib/Net/GitHub/V3/Query.pm
@@ -451,7 +451,8 @@ sub __build_methods {
             # Add methods next... and close...
             # Make method names singular (next_comments to next_comment)
             $m =~ s/s$//;
-            *{"${package}::next_${m}"} = sub {
+            my $m_name = ref $paginate ? $paginate->{name} : $m;
+            *{"${package}::next_${m_name}"} = sub {
                 my $self = shift;
 
                 # count how much %s inside u
@@ -471,7 +472,7 @@ sub __build_methods {
 
                 return $self->next($u);
             };
-            *{"${package}::close_${m}"} = sub {
+            *{"${package}::close_${m_name}"} = sub {
                 my $self = shift;
 
                 # count how much %s inside u

--- a/lib/Net/GitHub/V3/ResultSet.pm
+++ b/lib/Net/GitHub/V3/ResultSet.pm
@@ -1,0 +1,76 @@
+package Net::GitHub::V3::ResultSet;
+
+our $VERSION = '0.01';
+our $AUTHORITY = 'cpan:FAYLAND';
+
+use Types::Standard qw(Int Str ArrayRef Bool);
+use Moo;
+
+has 'url'      => ( is => 'rw', isa => Str,      required => 1);
+has 'results'  => ( is => 'rw', isa => ArrayRef, default => sub { [] } );
+has 'cursor'   => ( is => 'rw', isa => Int,      default => 0 );
+has 'done'     => ( is => 'rw', isa => Bool,     default => 0 );
+has 'next_url' => ( is => 'rw', isa => Str );
+
+no Moo;
+
+1;
+__END__
+
+=head1 NAME
+
+Net::GitHub::V3::ResultSet
+
+=head1 SYNOPSIS
+
+For use by the role L<Net::GitHub::V3::Query>:
+
+    use Net::GitHub::V3::ResultSet;
+
+    $result_set = Net::GitHub::V3::ResultSet->new( url => $url );
+    ...
+
+=head1 DESCRIPTION
+
+Objects in this class store the current status of a GitHub query while
+the user iterates over individual items.  This happens behind the
+scenes, users of Net::GitHub::V3 don't need to know about this class.
+
+Each of the V3 submodules holds one of these objects for every
+different pageable query which it handles.
+
+The attributes have the following function:
+
+=over 4
+
+=item url
+
+Required for creating the object: This is the URL where a pageable
+GitHub query starts, and this URL will be used to identify the
+pagination when retrieving the next object, and also for the first
+call to the GitHub API.
+
+=item results
+
+An array reference holding the current page as retrieved by the most
+recent call to the GitHub API.
+
+=item cursor
+
+An integer pointing to the "next" position within the current page
+from which the next method will fetch an item.
+
+=item done
+
+A boolean indicating that there's no more item to be fetched from the
+API: The current results are the last.
+
+=item next_url
+
+The url from which more results can be fetched.  Will be empty if
+there are no more pages.
+
+=back
+
+=cut
+

--- a/lib/Net/GitHub/V3/Users.pm
+++ b/lib/Net/GitHub/V3/Users.pm
@@ -29,12 +29,29 @@ sub add_email {
 sub remove_email {
     (shift)->query( 'DELETE', '/user/emails', [ @_ ] );
 }
+
 sub followers {
     my ($self, $user) = @_;
 
     my $u = $user ? "/users/" . uri_escape($user) . '/followers' : '/user/followers';
     return $self->query($u);
 }
+
+sub next_follower {
+    my ($self, $user) = @_;
+
+    my $u = $user ? "/users/" . uri_escape($user) . '/followers' : '/user/followers';
+    return $self->next($u);
+}
+
+sub close_follower {
+    my ($self, $user) = @_;
+
+    my $u = $user ? "/users/" . uri_escape($user) . '/followers' : '/user/followers';
+    return $self->close($u);
+}
+
+
 sub following {
     my ($self, $user) = @_;
 
@@ -42,16 +59,30 @@ sub following {
     return $self->query($u);
 }
 
+sub next_following {
+    my ($self, $user) = @_;
+
+    my $u = $user ? "/users/" . uri_escape($user) . '/following' : '/user/following';
+    return $self->next($u);
+}
+
+sub close_following {
+    my ($self, $user) = @_;
+
+    my $u = $user ? "/users/" . uri_escape($user) . '/following' : '/user/following';
+    return $self->close($u);
+}
+
 ## build methods on fly
 my %__methods = (
 
-    emails => { url => "/user/emails" },
+    emails => { url => "/user/emails", paginate => 1 },
 
     is_following => { url => "/user/following/%s", check_status => 204 },
     follow => { url => "/user/following/%s", method => 'PUT', check_status => 204 },
     unfollow => { url => "/user/following/%s", method => 'DELETE', check_status => 204 },
 
-    keys => { url => "/user/keys" },
+    keys => { url => "/user/keys", paginate => 1 },
     key  => { url => "/user/keys/%s" },
     create_key => { url => "/user/keys", method => 'POST', args => 1 },
     update_key => { url => "/user/keys/%s", method => 'PATCH', args => 1 },
@@ -118,6 +149,7 @@ L<http://developer.github.com/v3/users/emails/>
     $user->add_email( 'another@email.com' );
     $user->add_email( 'batch1@email.com', 'batch2@email.com' );
     my $emails = $user->emails;
+    while ($email = $user->next_email) { ...; }
     $user->remove_email( 'another@email.com' );
     $user->remove_email( 'batch1@email.com', 'batch2@email.com' );
 
@@ -133,10 +165,18 @@ L<http://developer.github.com/v3/users/followers/>
 
 =item following
 
+=item next_follower
+
+=item next_following
+
     my $followers = $user->followers;
     my $followers = $user->followers($user);
     my $following = $user->following;
     my $following = $user->following($user);
+    my $next_follower = $user->next_follower
+    my $next_follower = $user->next_follower($user)
+    my $next_following = $user->next_following
+    my $next_following = $user->next_following($user)
 
 =item is_following
 
@@ -168,6 +208,7 @@ L<http://developer.github.com/v3/users/keys/>
 =item delete_key
 
     my $keys = $user->keys;
+    while (my $key = $user->next_key) { ...; }
     my $key  = $user->key($key_id); # get key
     $user->create_key({
         title => 'title',

--- a/xt/v3/100-users.t
+++ b/xt/v3/100-users.t
@@ -16,8 +16,12 @@ diag( 'Using user = ' . $ENV{GITHUB_USER} );
 ok( $gh );
 ok( $user );
 
+# Remember the original value of bio
+my $ou = $user->show();
+my $obio = $ou->{bio};
+
 diag( 'Updating ..' );
-my $bio = 'another Perl programmer and Father';
+my $bio = 'Testing Net::GitHub - please come back in a minute';
 my $uu = $user->update( bio => $bio );
 is($uu->{bio}, $bio);
 
@@ -27,6 +31,9 @@ is($u->{bio}, $bio);
 delete $u->{updated_at}; delete $uu->{updated_at};
 is_deeply($u, $uu);
 
+# Restore bio
+my $ru = $user->update( bio => $obio );
+is($ru->{bio},$obio,"Value of user's Bio restored");
 =pod
 
 diag("Testing follow/unfollow");

--- a/xt/v3/400-pagination.t
+++ b/xt/v3/400-pagination.t
@@ -1,0 +1,104 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+use Test::More;
+use Net::GitHub::V3;
+use Net::GitHub::V3::Iterator;
+
+# For this test we are using the repository of Net::GitHub itself.
+# We filter for "all" states to make sure that the test doesn't fail
+# if at some time there are not enough open issues!
+# This test makes two API calls.
+
+plan skip_all => 'Please export environment variable GITHUB_USER/GITHUB_PASS'
+     unless $ENV{GITHUB_USER} and $ENV{GITHUB_PASS};
+
+my $gh = Net::GitHub::V3->new( login => $ENV{GITHUB_USER},
+                               pass => $ENV{GITHUB_PASS});
+diag( 'Using user = ' . $ENV{GITHUB_USER} );
+
+$gh->set_default_user_repo('fayland', 'perl-net-github');
+$gh->per_page(2);
+my $issue = $gh->issue;
+
+ok( $gh );
+ok( $issue );
+my $result;
+
+# Testing the guts, checking result set internals to see whether a
+# HTTP request has been performed
+
+my $url   = '/repos/fayland/perl-net-github/issues?state=all';
+$result = $issue->next($url);
+ok($result);
+is($issue->result_sets->{$url}->cursor,1,"First  result of first  page");
+diag $result->{title};
+
+$result = $issue->next($url);
+ok($result);
+is($issue->result_sets->{$url}->cursor,2,"Second result of first  page");
+diag $result->{title};
+
+$result = $issue->next($url);
+ok($result);
+is($issue->result_sets->{$url}->cursor,1,"First result of second page");
+diag $result->{title};
+
+$issue->close($url);
+
+# Now testing with the "official" pagination interfaces.
+# We use the *closed* issues of perl-net-github because they should be
+# rather stable, keeping the tests valid.
+#
+# We iterate through the issues until we have a defined title, then
+# through the comments for this issue until we have a defined author.
+
+$issue->per_page(100); # Keep API usage back to normal
+
+my $issue_found = '';
+my $search_title = 'rate limit headers';
+my $search_author = 'fayland';
+my $search_body = "ty, new version uploaded. Thanks\n";
+
+my $issue_count = 0;
+ISSUE:
+while ( my $closed_issue =  $issue->next_repos_issue({state => 'closed'}) ) {
+    if ($closed_issue->{title} ne $search_title) {
+        $issue_count++;
+        next ISSUE;
+    }
+    $issue_found = $issue_count;
+    pass("Issue '$search_title' found after $issue_found iterations");
+    my $issue_number = $closed_issue->{number};
+
+    my $comment_found = 0;
+  COMMENT:
+    while ( my $comment = $issue->next_comment($issue_number) ) {
+        next COMMENT unless $comment->{user}{login} eq $search_author;
+        $comment_found = 1;
+        is($comment->{body},$search_body);
+    }
+    $issue->close_comment($issue_number);
+    ok($comment_found,"Comment by '$search_author' found");
+
+    my $event_found = 0;
+  EVENT:
+    while ( my $event = $issue->next_event($issue_number) ) {
+        next EVENT unless $event->{event} eq 'closed';
+        $event_found = 1;
+        is($event->{actor}{login},$search_author,
+           "'$search_author' closed this issue");
+    }
+    ok($event_found);
+    $issue->close_event($issue_number);
+    last ISSUE;
+}
+
+if (! $issue_found) {
+    fail("Issue not found, no tests for comments, events etc.");
+}
+
+$issue->close_repos_issue({state => 'closed'});
+
+done_testing;


### PR DESCRIPTION
This pull request is motivated by the CPAN Pull Request Challenge, http://cpan-prc.org/.
It is a suggestion for an iteration over individual items instead of "pages".  Using this iteration, the caller does not need to manage API calls to fetch more pages of results.
The first three commits are small fixes to the docs and tests, which are actually unrelated to pagination.  The fourth contains the basic iteration mechanism plus the implementation for the submodule Net::GitHub::V3::Issues, and documentation for this submodule, as well as a first test script.
The other submodules are pretty straightforward and will follow, but I've a different assignment for the rest of the week, and maybe you can review the proposal from what I've done with Issues.pm.

Unfortunately, I am not a regular user of this module, so I'd welcome pointers to typical workflows or relevant reverse dependencies which I could add as tests.