### PR TITLE
add whatis entry to POD

### DIFF
--- a/lib/Net/GitHub/V3/ResultSet.pm
+++ b/lib/Net/GitHub/V3/ResultSet.pm
@@ -19,7 +19,7 @@ __END__
 
 =head1 NAME
 
-Net::GitHub::V3::ResultSet
+Net::GitHub::V3::ResultSet - GitHub query iteration helper
 
 =head1 SYNOPSIS
 


### PR DESCRIPTION

In Debian we are currently applying the following patch to
Net-GitHub.
We thought you might be interested in it too.

    Description: add whatis entry to POD
    Origin: vendor
    Author: gregor herrmann <gregoa@debian.org>
    Last-Update: 2018-03-17
    

The patch is tracked in our Git repository at
https://salsa.debian.org/perl-team/modules/packages/libnet-github-perl/raw/master/debian/patches/pod-whatis.patch

Thanks for considering,
  gregor herrmann,
  Debian Perl Group
