### PR TITLE
Review Requests API became an official part of API v3

### DIFF
--- a/lib/Net/GitHub/V3/PullRequests.pm
+++ b/lib/Net/GitHub/V3/PullRequests.pm
@@ -63,9 +63,9 @@ my %__methods = (
     delete_comment => { url => "/repos/%s/%s/pulls/comments/%s", method => 'DELETE', check_status => 204 },
 
     # https://developer.github.com/v3/pulls/review_requests/
-    reviewers => { url => "/repos/%s/%s/pulls/%s/requested_reviewers", preview => "black-cat-preview", paginate => 1 },
-    add_reviewers => { url => "/repos/%s/%s/pulls/%s/requested_reviewers", method => 'POST', args => 1, preview => "black-cat-preview" },
-    delete_reviewers => { url => "/repos/%s/%s/pulls/%s/requested_reviewers", method => 'DELETE', check_status => 204, args => 1, preview => "black-cat-preview" },
+    reviewers => { url => "/repos/%s/%s/pulls/%s/requested_reviewers", paginate => 1 },
+    add_reviewers => { url => "/repos/%s/%s/pulls/%s/requested_reviewers", method => 'POST', args => 1 },
+    delete_reviewers => { url => "/repos/%s/%s/pulls/%s/requested_reviewers", method => 'DELETE', check_status => 204, args => 1 },
 );
 __build_methods(__PACKAGE__, %__methods);
 

--- a/lib/Net/GitHub/V3/PullRequests.pm
+++ b/lib/Net/GitHub/V3/PullRequests.pm
@@ -193,12 +193,13 @@ L<https://developer.github.com/v3/pulls/review_requests/>
 =item delete_reviewers
 
     my @reviewers = $pull_request->reviewers($pull_number);
-    while (my $reviewer = $pull_request->next_reviever($pull_number)) { ...; }
     my $result = $pull_request->add_reviewers($pull_number, {
         reviewers => [$user1, $user2],
+        team_reviewers => [$team1],
     );
     my $result = $pull_request->delete_reviewers($pull_number, {
         reviewers => [$user1, $user2],
+        team_reviewers => [$team1],
     );
 
 =back


### PR DESCRIPTION
Since the Review Request API became an official part of API v3 on January 24, 2018, changed it to use v3 as the version in the Accept header.
https://developer.github.com/changes/2018-01-24-end-thor-preview/