### PR TITLE
Use named parameters in API requests

### DIFF
--- a/lib/Net/GitHub/V3/Orgs.pm
+++ b/lib/Net/GitHub/V3/Orgs.pm
@@ -45,9 +45,9 @@ my %__methods = (
     is_public_member => { url => "/orgs/%s/public_members/%s", check_status => 204 },
     publicize_member => { url => "/orgs/%s/public_members/%s", method => 'PUT', check_status => 204 },
     conceal_member => { url => "/orgs/%s/public_members/%s", method => 'DELETE', check_status => 204 },
-    membership => { url => "/orgs/:org/memberships/:username", method => 'GET' },
-    update_membership => { url => "/orgs/:org/memberships/:username", method => 'PUT', args => 1 },
-    delete_membership => { url => "/orgs/:org/memberships/:username", method => 'DELETE', check_status => 204 },
+    membership => { url => "/orgs/:org/memberships/:username", method => 'GET', v => 2 },
+    update_membership => { url => "/orgs/:org/memberships/:username", method => 'PUT', args => 1, v => 2 },
+    delete_membership => { url => "/orgs/:org/memberships/:username", method => 'DELETE', check_status => 204, v => 2 },
     # Org Teams API
     teams => { url => "/orgs/%s/teams", paginate => 1 },
     team  => { url => "/teams/%s" },
@@ -64,6 +64,7 @@ my %__methods = (
     add_team_repos => { url => "/teams/%s/repos/%s", method => 'PUT', args => 1, check_status => 204 },
     delete_team_repos => { url => "/teams/%s/repos/%s", method => 'DELETE', check_status => 204 },
 );
+
 __build_methods(__PACKAGE__, %__methods);
 
 no Moo;
@@ -160,7 +161,7 @@ L<http://developer.github.com/v3/orgs/members/>
 
 =item delete_membership
 
-    my $membership = $org->membership('perlchina', 'fayland');
+    my $membership = $org->membership( { org => 'perlchina', username => 'fayland' } );
     my $membership = $org->update_membership('perlchina', 'fayland', {
         role => 'admin',
     });

--- a/lib/Net/GitHub/V3/Repos.pm
+++ b/lib/Net/GitHub/V3/Repos.pm
@@ -269,7 +269,7 @@ my %__methods = (
 
     # http://developer.github.com/v3/repos/contents/
     readme => { url => "/repos/%s/%s/readme" },
-    get_content => { url => "/repos/%s/%s/contents/%s" },
+    get_content => { url => "/repos/:owner/:repo/contents/:path", v => 2 },
 
     # http://developer.github.com/v3/repos/downloads/
     downloads => { url => "/repos/%s/%s/downloads", paginate => 1 },
@@ -903,6 +903,29 @@ Check examples/upload_asset.pl for a working example.
     my $ok = $repos->delete_release_asset($release_id, $asset_id);
 
 =back
+
+=head3 Contents API
+
+L<https://developer.github.com/v3/repos/contents/>
+
+=over 4
+
+=item get_content
+
+Gets the contents of a file or directory in a repository.
+Specify the file path or directory in $path.
+If you omit $path, you will receive the contents of all files in the repository.
+
+    my $response = $repos->get_content( $owner, $repo, $path )
+        or
+        $repos->get_content(
+            { owner => $owner,  repo => $repo, path => $path },
+         )
+        or
+        $repos->get_content(
+            { owner => $owner,  repo => $repo, path => $path },
+            { ref => 'feature-branch' }
+         )
 
 =head3 Repo Deployment API
 


### PR DESCRIPTION
This commit is mainly here to open a discussion,
I think it would make sense to be able to use the urls as described in the GitHub API documentation

example: `"/repos/:owner/:repo/contents/:path?ref=:ref"`
or `/orgs/:org/memberships/:username`

then when calling a function being able to provide a hash reference

something like this
`$Net::GitHub::V3->new(...)->org->membership( { org => 'perlchina', username => 'fayland' } )`

note that we can reserve two name arguments for the args or either use an additional hash ref

The commit attached to this PR should not be merged and is mainly there to illustrate the idea.
If you like the idea, I can provide a tidy PR where we could automatically detect if we are called using a hashef or not. So the final user can still use the old syntax, while we start providing the updated one
