### PR TITLE
Basic generic iterator

### DIFF
--- a/lib/Net/GitHub/V3.pm
+++ b/lib/Net/GitHub/V3.pm
@@ -292,7 +292,19 @@ For brevity and because they usually are not needed, the close_xxx
 methods are not listed with their modules.  It is guaranteed that
 I<every> next_xxx method has a corresponding close_xxx method.
 
+=head3 Alternate iterator over individual items:
 
+If next_xxx and close_xxx methods are not available for your pagination
+method you can use a generic iterator using the C<iterate> helper.
+
+    $gh->issues->iterate( 'repos_issues', [ @args ], sub {
+        my $issue = shift;
+
+        ... # do something with $issue
+
+        return 1; # if you want to continue iterating
+        return;   # when you want to interrupt the iteration process
+    } );
 
 =head3 ua
 


### PR DESCRIPTION
Paginate methods can generaly use next_xxx and
close_xxx helpers to iterate through all items.

But this requires to implement these specific
helpers. The idea here is to provide another
way to iterate through items without the need
to define these special helpers.

This is mainly a combo of 'has_next_page' and
'next_page' loop together with a callback function.